### PR TITLE
Remove Galactic Header Menu Link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,31 +19,26 @@ disableHugoGeneratorInject = true
     name = "About"
     url = "/about/"
     weight = 1
-  [[menu.main]]  
-    identifer = "galactic"
-    name = "Galactic CTF"
-    url = "/galactic/"
-    weight = 2
   [[menu.main]]
     identifier = "posts"
     name = "Posts"
     url = "/posts/"
-    weight = 3
+    weight = 2
   [[menu.main]]
     identifier = "tags"
     name = "Tags"
     url = "/tags/"
-    weight = 4
+    weight = 3
   [[menu.main]]
     identifier = "categories"
     name = "Categories"
     url = "/categories/"
-    weight = 5
+    weight = 4
   [[menu.main]]
     identifier = "schedule"
     name = "Schedule"
     url = "/schedule/"
-    weight = 6
+    weight = 5
 [params]
   version = "0.2.X"
   description = "The official site of CUEH ComSec - Coventry University's Ethical Hacking Society. Meeting weekly, we plan to use this site to show the progress of the group."


### PR DESCRIPTION
Page removed in https://github.com/Cov-ComSec/Cov-ComSec.github.io/commit/54c76eedd0f83e65646da8efba73d1e98fa017f9, but link was never removed (so now displays a 404)